### PR TITLE
IHP-5 - fix ClassNotFoundException from sbt-assembly

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,8 +16,13 @@ val assemblyStrategy = assembly / assemblyMergeStrategy := {
   case PathList("META-INF", "maven", "org.webjars", "swagger-ui", "pom.properties") =>
     MergeStrategy.singleOrError
 
+  // lot of metainf folders might override this project's metainf which will result in error:
+  // Could not find or load main class com.github.baklanovsoft.imagehosting.resizer.Main
+
+  case PathList("META-INF", xs @ _*) => MergeStrategy.discard
+
   // deduplicate error because of logback, this will fix
-  case x                                                                            =>
+  case x =>
     MergeStrategy.first
 }
 

--- a/common/src/main/scala/com/github/baklanovsoft/imagehosting/kafka/KafkaConsumer.scala
+++ b/common/src/main/scala/com/github/baklanovsoft/imagehosting/kafka/KafkaConsumer.scala
@@ -1,4 +1,4 @@
-package com.github.baklanovsoft.imagehosting.imagehosting.kafka
+package com.github.baklanovsoft.imagehosting.kafka
 
 import cats.implicits._
 import cats.effect.kernel.{Async, Resource}

--- a/common/src/main/scala/com/github/baklanovsoft/imagehosting/kafka/KafkaJsonDeserializer.scala
+++ b/common/src/main/scala/com/github/baklanovsoft/imagehosting/kafka/KafkaJsonDeserializer.scala
@@ -1,9 +1,9 @@
-package com.github.baklanovsoft.imagehosting.imagehosting.kafka
+package com.github.baklanovsoft.imagehosting.kafka
 
 import cats.effect.kernel.Sync
 import cats.implicits._
 import com.github.baklanovsoft.imagehosting.error.DecodingError
-import com.github.baklanovsoft.imagehosting.imagehosting.kafka.KafkaJsonDeserializer.KafkaJsonDecodingError
+import KafkaJsonDeserializer.KafkaJsonDecodingError
 import fs2.kafka._
 import io.circe.Decoder
 import io.circe.jawn.decodeByteArray

--- a/common/src/main/scala/com/github/baklanovsoft/imagehosting/s3/MinioClient.scala
+++ b/common/src/main/scala/com/github/baklanovsoft/imagehosting/s3/MinioClient.scala
@@ -1,4 +1,4 @@
-package com.github.baklanovsoft.imagehosting.imagehosting.s3
+package com.github.baklanovsoft.imagehosting.s3
 
 import cats.effect.kernel.Sync
 import io.minio.{MakeBucketArgs, MinioClient => MinioClientJava, PutObjectArgs, RemoveBucketArgs}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     container_name: resizer1
     depends_on:
       - kafka-init
+      - minio
     environment:
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
       CONSUMER_GROUP_ID: resizer-local-test
@@ -88,10 +89,10 @@ services:
       - "9000:9000"
       - "9001:9001"
     volumes:
-      - images-data:/data
+      - minio-data:/data
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin
 
 volumes:
-  images-data:
+  minio-data:

--- a/resizer/Dockerfile
+++ b/resizer/Dockerfile
@@ -2,7 +2,6 @@ FROM eclipse-temurin:17.0.6_10-jre-jammy
 
 WORKDIR /opt/app
 
-#COPY ./application.conf ./app/target/scala-2.13/image-hosting-processing-resizer-assembly-0.1.0-SNAPSHOT.jar ./
 COPY ./target/scala-2.13/image-hosting-processing-resizer-assembly-0.1.0-SNAPSHOT.jar ./
 
 ENTRYPOINT ["java", "-cp", "image-hosting-processing-resizer-assembly-0.1.0-SNAPSHOT.jar", "com.github.baklanovsoft.imagehosting.resizer.Main"]

--- a/resizer/src/main/scala/com/github/baklanovsoft/imagehosting/resizer/Main.scala
+++ b/resizer/src/main/scala/com/github/baklanovsoft/imagehosting/resizer/Main.scala
@@ -2,8 +2,8 @@ package com.github.baklanovsoft.imagehosting.resizer
 
 import cats.effect.{ExitCode, IO, IOApp}
 import com.github.baklanovsoft.imagehosting.NewImage
-import com.github.baklanovsoft.imagehosting.imagehosting.kafka.{KafkaConsumer, KafkaJsonDeserializer}
-import com.github.baklanovsoft.imagehosting.imagehosting.s3.MinioClient
+import com.github.baklanovsoft.imagehosting.kafka.{KafkaConsumer, KafkaJsonDeserializer}
+import com.github.baklanovsoft.imagehosting.s3.MinioClient
 import fs2.kafka.commitBatchWithin
 import org.typelevel.log4cats.LoggerFactory
 import org.typelevel.log4cats.slf4j.Slf4jFactory


### PR DESCRIPTION
Resolves #5 

Adding minio library make sbt-assembly build fail with Class Not Found exception because manifest was overridden.

https://stackoverflow.com/questions/46287789/running-an-uber-jar-from-sbt-assembly-results-in-error-could-not-find-or-load-m